### PR TITLE
Develop

### DIFF
--- a/CLImber.Example/Program.cs
+++ b/CLImber.Example/Program.cs
@@ -38,7 +38,7 @@ namespace CLImber.Example
         }
     }
 
-    [CommandClass("network")]
+    [CommandClass("network", ShortDescription = "Creates a network entry with an IP address")]
     public class NetworkCommand
     {
         [CommandHandler]
@@ -57,7 +57,7 @@ namespace CLImber.Example
             Console.WriteLine("This method is invoked entirely via reflection");
         }
 
-        [CommandHandler]
+        [CommandHandler(ShortDescription = "Prints a status report with the supplied title.")]
         public void StatusReportWithTitle(string title)
         {
             Console.WriteLine("Status report with title: " + title);

--- a/CLImber.Example/Program.cs
+++ b/CLImber.Example/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 
 namespace CLImber.Example
 {
@@ -18,7 +19,7 @@ namespace CLImber.Example
         static void CLImberConfig()
         {
             _handler.RegisterResource<ITestResource>(new TestResource())
-                .RegisterTypeConverter<System.Net.IPAddress>(new ArgToIP());
+                .RegisterTypeConverter<IPAddress>((arg) => IPAddress.Parse(arg));
         }
 
         static readonly CLIHandler _handler = new CLIHandler();
@@ -42,7 +43,7 @@ namespace CLImber.Example
     public class NetworkCommand
     {
         [CommandHandler]
-        public void WhatIsTheIP(System.Net.IPAddress ip)
+        public void WhatIsTheIP(IPAddress ip)
         {
             Console.WriteLine("We were successfully passed an IP Address! " + ip);
         }
@@ -66,16 +67,6 @@ namespace CLImber.Example
         public StatusCmdHandler()
         {
             Console.WriteLine("Default constructor");
-        }
-    }
-
-
-    public class ArgToIP
-        : IArgumentTypeConverter
-    {
-        public object ConvertArgument(string arg)
-        {
-            return System.Net.IPAddress.Parse(arg);
         }
     }
 }

--- a/CLImber/CLIHandler.cs
+++ b/CLImber/CLIHandler.cs
@@ -7,10 +7,11 @@ namespace CLImber
 {
     public class CLIHandler
     {
-        private readonly Dictionary<Type, IArgumentTypeConverter> _converters = new Dictionary<Type, IArgumentTypeConverter>();
-        public CLIHandler RegisterTypeConverter<T>(IArgumentTypeConverter converter)
+        private readonly Dictionary<Type, Func<string, object>> _converterFuncs = new Dictionary<Type, Func<string, object>>();
+
+        public CLIHandler RegisterTypeConverter<T>(Func<string, object> converterFunc)
         {
-            _converters[typeof(T)] = converter;
+            _converterFuncs[typeof(T)] = converterFunc;
             return this;
         }
 
@@ -23,7 +24,7 @@ namespace CLImber
 
         public CLIHandler()
         {
-            _converters[typeof(int)] = new ArgToInt();
+            _converterFuncs[typeof(int)] = (arg) => int.Parse(arg);
         }
 
         public void Handle(IEnumerable<string> args)
@@ -115,11 +116,10 @@ namespace CLImber
             if (desiredType == typeof(string))
                 return parameter;
 
-            if (!_converters.ContainsKey(desiredType))
+            if (!_converterFuncs.ContainsKey(desiredType))
                 throw new Exception($"Converter not registered for type {desiredType}");
-    
-            return _converters[desiredType]
-                .ConvertArgument(parameter);
+
+            return _converterFuncs[desiredType](parameter);
         }
     }
 }

--- a/CLImber/CommandClassAttribute.cs
+++ b/CLImber/CommandClassAttribute.cs
@@ -6,6 +6,7 @@ namespace CLImber
     public class CommandClassAttribute
         : System.Attribute
     {
+        public string ShortDescription { get; set; }
         public string CommandName { get; }
 
         public CommandClassAttribute(string commandName)

--- a/CLImber/CommandHandlerAttribute.cs
+++ b/CLImber/CommandHandlerAttribute.cs
@@ -6,6 +6,6 @@ namespace CLImber
     public class CommandHandlerAttribute
         : System.Attribute
     {
-
+        public string ShortDescription { get; set; }
     }
 }

--- a/CLImber/UsageDocumenter.cs
+++ b/CLImber/UsageDocumenter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Linq;
 using System.Text;
 

--- a/CLImber/UsageDocumenter.cs
+++ b/CLImber/UsageDocumenter.cs
@@ -19,17 +19,25 @@ namespace CLImber
             {
 
                 var cmdName = AssemblySearcher.GetCommandName(type);
-                Console.WriteLine($"Usage of {cmdName} comand:");
+                Console.WriteLine($"{cmdName} command");
+                var desc = type.GetCustomAttributes(typeof(CommandClassAttribute), false).Cast<CommandClassAttribute>().First().ShortDescription;
+                if (desc?.Length > 0)
+                {
+                    Console.WriteLine(desc);
+                }
+
+                Console.WriteLine($"usage:");
 
                 foreach (var method in AssemblySearcher.GetCommandMethods(type))
                 {
+                    var handlerDesc = method.GetCustomAttributes(typeof(CommandHandlerAttribute), false).Cast<CommandHandlerAttribute>().First().ShortDescription;
                     StringBuilder sb = new StringBuilder();
                     sb.Append(cmdName).Append(" ");
                     foreach (var param in method.GetParameters())
                     {
                         sb.Append(param.Name).Append(" ");
                     }
-                    Console.WriteLine($"  {sb}");
+                    Console.WriteLine($"  {sb,-60} {handlerDesc}");
                 }
                 Console.WriteLine("\n");
             }


### PR DESCRIPTION
An incremental update providing some basic functionality improvements:

New features:
- When no commands are supplied CLImber will print out usage information for all commands in the assembly.
- Instead of requiring a class to implement ITypeConverter, CLImber now accepts Func arguments for type conversion
- CommandClass and CommandHandler attributes now accept an optional short description that is printed with the usage information.