### PR TITLE
Fix Problem Handling Options with Values

### DIFF
--- a/CLImber.Tests/CLIHandlerTests.cs
+++ b/CLImber.Tests/CLIHandlerTests.cs
@@ -17,6 +17,8 @@ namespace CLImber.Tests
 
         public static int IntOption { get; private set; } = 0;
 
+        public static string CommandArg { get; private set; } = string.Empty;
+
         public DummyCommand()
         {
             CallCount = 0;
@@ -24,12 +26,20 @@ namespace CLImber.Tests
             StringOption = string.Empty;
             IntOption = 0;
             OtherFlag = false;
+            CommandArg = string.Empty;
         }
 
         [CommandHandler]
         public void DefaultHandler()
         {
             CallCount++;
+        }
+
+        [CommandHandler]
+        public void CommandHandlerWithArgs(string arg1)
+        {
+            CallCount++;
+            CommandArg = arg1;
         }
 
         [CommandOption("flag", Abbreviation = 'f')]
@@ -94,7 +104,6 @@ namespace CLImber.Tests
         public void Handle_ShouldFindClassesInAssembly_WhenDecoratedWithCommandClass()
         {
             string[] arguments = { "test_command" };
-            var callCountBefore = DummyCommand.CallCount;
 
             _sut.Handle(arguments);
 
@@ -191,5 +200,20 @@ namespace CLImber.Tests
             DummyCommand.OtherFlag.Should().BeTrue();
             DummyCommand.CallCount.Should().Be(1);
         }
+
+        [Fact]
+        public void Handle_SetsOptionsAndParsesArgs_WhenBothArePresent()
+        {
+            string[] arguments = { "test_command", "-fo", "--stringOption=someValue", "this is the argument"};
+
+            _sut.Handle(arguments);
+
+            DummyCommand.Flag.Should().BeTrue();
+            DummyCommand.OtherFlag.Should().BeTrue();
+            DummyCommand.StringOption.Should().Be("someValue");
+            DummyCommand.CallCount.Should().Be(1);
+            DummyCommand.CommandArg.Should().Be("this is the argument");
+        }
+
     }
 }

--- a/CLImber/CLImber.csproj
+++ b/CLImber/CLImber.csproj
@@ -6,7 +6,7 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageProjectUrl>https://github.com/JosephMartell/CLImber</PackageProjectUrl>
     <RepositoryUrl>https://github.com/JosephMartell/CLImber</RepositoryUrl>
-    <Version>0.5.2</Version>
+    <Version>0.5.3</Version>
     <Authors>Joseph Martell</Authors>
     <Description>CLImber is a Command Line Interface library.</Description>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
@@ -15,7 +15,8 @@
 - Implements options.
 
 *0.5.1 is being uploaded because 0.5.0 did not make the CommandOptionAttribute class public.
-*0.5.2 is a bug-fix release. Release 0.5.0 did not properly parse commands seperately from options.</PackageReleaseNotes>
+*0.5.2 is a bug-fix release. Release 0.5.0 did not properly parse commands seperately from options.
+*0.5.3 is a bug-fix release. CLImber would not call the proper command handler if an option taking a parameter was included in the command line.</PackageReleaseNotes>
     <RepositoryType>git</RepositoryType>
     <PackageId>JM.CLImber</PackageId>
   </PropertyGroup>


### PR DESCRIPTION
Fixed a problem where an option with a value would cause the actual
command handler method to not be called. Added suitable tests for
this condition as well.