### PR TITLE
Release 0.6.0

### DIFF
--- a/CLImber.Example/AddCmdHandler.cs
+++ b/CLImber.Example/AddCmdHandler.cs
@@ -1,40 +1,13 @@
 ﻿using System;
-using System.Net;
 namespace CLImber.Example
 {
-    [CommandClass("add")]
+    [CommandClass("add", ShortDescription = "Add numbers together")]
     public class AddCmdHandler
     {
         [CommandHandler]
-        public void AddDHCPProfile(string name)
+        public void AddNumbers(decimal num1, decimal num2)
         {
-            Console.WriteLine("Add DHCP Profile named: " + name);
-
-
-        }
-
-        [CommandHandler]
-        public void AddStaticProfile(string name, System.Net.IPAddress ip, System.Net.IPAddress subnet)
-        {
-            Console.WriteLine("Add static profile with only an ip (" + ip + ") and subnet (" + subnet + ")");
-
-
-        }
-
-        [CommandHandler]
-        public void AddStaticProfile(string name, IPAddress ip, IPAddress subnet, IPAddress gateway)
-        {
-            Console.WriteLine($"Add static profile with ip, subnet, & gw: {ip}, {subnet}, {gateway}");
-
-
-        }
-
-        [CommandHandler]
-        public void AddStaticProfile(string name, IPAddress ip, IPAddress subnet, IPAddress gateway, IPAddress DNS)
-        {
-            Console.WriteLine($"Add static profile with ip, subnet, gw, & DNS: {ip}, {subnet}, {gateway}, {DNS}");
-
-
+            Console.WriteLine($"Answer: {num1 + num2}");
         }
     }
 }

--- a/CLImber.Example/Divide.cs
+++ b/CLImber.Example/Divide.cs
@@ -1,0 +1,13 @@
+﻿using System;
+namespace CLImber.Example
+{
+    [CommandClass("div", ShortDescription = "Divide numbers")]
+    public class Divide
+    {
+        [CommandHandler]
+        public void DivideNumbers(decimal num1, decimal num2)
+        {
+            Console.WriteLine($"Answer: {num1 / num2}");
+        }
+    }
+}

--- a/CLImber.Example/Multiply.cs
+++ b/CLImber.Example/Multiply.cs
@@ -1,0 +1,13 @@
+﻿using System;
+namespace CLImber.Example
+{
+    [CommandClass("mul", ShortDescription = "Multiply numbers")]
+    public class Multiply
+    {
+        [CommandHandler]
+        public void MultiplyNumbers(decimal num1, decimal num2)
+        {
+            Console.WriteLine($"Answer: {num1 * num2}");
+        }
+    }
+}

--- a/CLImber.Example/Program.cs
+++ b/CLImber.Example/Program.cs
@@ -1,72 +1,18 @@
-﻿using System;
-using System.Net;
-
-namespace CLImber.Example
+﻿namespace CLImber.Example
 {
-    public interface ITestResource
-    {
-        string Resource { get; }
-    }
-
-    public class TestResource
-        : ITestResource
-    {
-        public string Resource => "This is the test resource";
-    }
 
     class Program
     {
+        static readonly CLIHandler _handler = new CLIHandler();
         static void CLImberConfig()
         {
-            _handler.RegisterResource<ITestResource>(new TestResource())
-                .RegisterTypeConverter<IPAddress>((arg) => IPAddress.Parse(arg));
+            _handler.RegisterTypeConverter<decimal>(s => decimal.Parse(s));
         }
 
-        static readonly CLIHandler _handler = new CLIHandler();
         static void Main(string[] args)
         {
             CLImberConfig();
-            if (args.Length == 0)
-            {
-                _handler.Handle(new string[] { "status", "Title" });
-                _handler.Handle(new string[] { "add", "test profile", "192.168.1.99", "255.255.255.0" });
-                _handler.Handle(new string[] { });
-            }
-            else
-            {
-                _handler.Handle(args);
-            }
-        }
-    }
-
-    [CommandClass("network", ShortDescription = "Creates a network entry with an IP address")]
-    public class NetworkCommand
-    {
-        [CommandHandler]
-        public void WhatIsTheIP(IPAddress ip)
-        {
-            Console.WriteLine("We were successfully passed an IP Address! " + ip);
-        }
-    }
-
-    [CommandClass("status")]
-    public class StatusCmdHandler
-    {
-        [CommandHandler]
-        public void NormalStatusReport()
-        {
-            Console.WriteLine("This method is invoked entirely via reflection");
-        }
-
-        [CommandHandler(ShortDescription = "Prints a status report with the supplied title.")]
-        public void StatusReportWithTitle(string title)
-        {
-            Console.WriteLine("Status report with title: " + title);
-        }
-
-        public StatusCmdHandler()
-        {
-            Console.WriteLine("Default constructor");
+            _handler.Handle(args);
         }
     }
 }

--- a/CLImber.Example/Subtract.cs
+++ b/CLImber.Example/Subtract.cs
@@ -1,0 +1,13 @@
+﻿using System;
+namespace CLImber.Example
+{
+    [CommandClass("sub", ShortDescription = "Subtract numbers")]
+    public class Subtract
+    {
+        [CommandHandler]
+        public void SubNumbers(decimal num1, decimal num2)
+        {
+            Console.WriteLine($"Answer: {num1 - num2}");
+        }
+    }
+}

--- a/CLImber.Tests/CLIHandlerTests.cs
+++ b/CLImber.Tests/CLIHandlerTests.cs
@@ -78,7 +78,7 @@ namespace CLImber.Tests
             }
         }
 
-        [CommandOption("stringOption")]
+        [CommandOption("stringOption", Abbreviation = 's')]
         public string InstanceStringOption
         {
             get
@@ -91,7 +91,7 @@ namespace CLImber.Tests
             }
         }
 
-        [CommandOption("int")]
+        [CommandOption("int", Abbreviation = 'i')]
         public int InstanceIntOption
         {
             get
@@ -259,6 +259,40 @@ namespace CLImber.Tests
             DummyCommand.ResetIndicators();
 
             _sut.Handle(argumentsWithCase);
+            DummyCommand.CallCount.Should().Be(0);
+        }
+
+        [Fact]
+        public void Handle_SetsOptionValue_ForAbbreviatedOptions()
+        {
+            string[] arguments = { "test_command", "-s=someValue" };
+            _sut.Handle(arguments);
+            DummyCommand.StringOption.Should().BeEquivalentTo("someValue");
+
+        }
+
+        [Fact]
+        public void Handle_SetsOptionValue_WhenValueIsNextArgument()
+        {
+            string[] arguments = { "test_command", "-s", "someValue" };
+            _sut.Handle(arguments);
+            DummyCommand.StringOption.Should().BeEquivalentTo("someValue");
+
+        }
+        [Fact]
+        public void Handle_SetsOptionValue_WhenValueIsPartOfAggregateGroup()
+        {
+            string[] arguments = { "test_command", "-fs", "someValue" };
+            _sut.Handle(arguments);
+            DummyCommand.Flag.Should().BeTrue();
+            DummyCommand.StringOption.Should().BeEquivalentTo("someValue");
+        }
+
+        [Fact]
+        public void Handle_ShouldNotRun_WhenMultipleAggregatesNeedValues()
+        {
+            string[] arguments = { "test_command", "-fsi", "someValue", "5" };
+            _sut.Handle(arguments);
             DummyCommand.CallCount.Should().Be(0);
         }
     }

--- a/CLImber.Tests/CLIHandlerTests.cs
+++ b/CLImber.Tests/CLIHandlerTests.cs
@@ -19,6 +19,16 @@ namespace CLImber.Tests
 
         public static string CommandArg { get; private set; } = string.Empty;
 
+        public static void ResetIndicators()
+        {
+            CallCount = 0;
+            Flag = false;
+            OtherFlag = false;
+            StringOption = string.Empty;
+            IntOption = 0;
+            CommandArg = string.Empty;
+        }
+
         public DummyCommand()
         {
             CallCount = 0;
@@ -121,8 +131,12 @@ namespace CLImber.Tests
             _sut.Handle(arguments);
             DummyCommand.CallCount.Should().Be(1);
 
+            DummyCommand.ResetIndicators();
+
             _sut.Handle(argumentsWithCapitols);
             DummyCommand.CallCount.Should().Be(1);
+
+            DummyCommand.ResetIndicators();
 
             _sut.Handle(argumentsWithRandomCapitols);
             DummyCommand.CallCount.Should().Be(1);
@@ -215,5 +229,37 @@ namespace CLImber.Tests
             DummyCommand.CommandArg.Should().Be("this is the argument");
         }
 
+        [Fact]
+        public void Handle_IgnoresTextCase_WhenRequested()
+        {
+            string[] argumentsWithCase = { "test_Command" };
+            string[] argumentsNoCase = { "test_command" };
+            _sut.IgnoreCommandCase = true;
+            
+            _sut.Handle(argumentsNoCase);
+            DummyCommand.CallCount.Should().Be(1);
+
+            DummyCommand.ResetIndicators();
+
+            _sut.Handle(argumentsWithCase);
+            DummyCommand.CallCount.Should().Be(1);
+
+        }
+
+        [Fact]
+        public void Handle_UsesTextCase_WhenRequested()
+        {
+            string[] argumentsWithCase = { "tEst_ComMand" };
+            string[] argumentsNoCase = { "test_command" };
+            _sut.IgnoreCommandCase = false;
+            
+            _sut.Handle(argumentsNoCase);
+            DummyCommand.CallCount.Should().Be(1);
+
+            DummyCommand.ResetIndicators();
+
+            _sut.Handle(argumentsWithCase);
+            DummyCommand.CallCount.Should().Be(0);
+        }
     }
 }

--- a/CLImber/AssemblySearcher.cs
+++ b/CLImber/AssemblySearcher.cs
@@ -18,15 +18,15 @@ namespace CLImber
             return cmdTypes;
         }
 
-        public static IEnumerable<Type> GetCommandClasses(string desiredCommand)
+        public static IEnumerable<Type> GetCommandClasses(string desiredCommand, bool ignoreCase = true)
         {
             var cmdTypes =
                 from a in AppDomain.CurrentDomain.GetAssemblies()
                 from t in a.GetTypes()
                 let attributes = t.GetCustomAttributes(typeof(CommandClassAttribute), true).Cast<CommandClassAttribute>()
-                from attribute in attributes.Cast<CommandClassAttribute>()
+                from attribute in attributes
                 where attributes != null && attributes.Count() > 0
-                  && attribute.CommandName.Equals(desiredCommand, StringComparison.OrdinalIgnoreCase)
+                  && attribute.CommandName.Equals(desiredCommand, ignoreCase ? StringComparison.CurrentCultureIgnoreCase : StringComparison.CurrentCulture)
                 select t;
 
             return cmdTypes;
@@ -56,13 +56,13 @@ namespace CLImber
                    select method;
         }
 
-        public static IEnumerable<PropertyInfo> GetCommandOptionPropertyByName(Type type, string optionName)
+        public static IEnumerable<PropertyInfo> GetCommandOptionPropertyByName(Type type, string optionName, bool ignoreCase = true)
         {
             var selectedOption = from op in type.GetProperties()
                                  let attribs = op.GetCustomAttributes<CommandOptionAttribute>()
                                  where (attribs.Count() > 0)
                                  from att in attribs
-                                 where att.Name.Equals(optionName, StringComparison.OrdinalIgnoreCase)
+                                 where att.Name.Equals(optionName, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal)
                                     || att.Abbreviation.ToString().Equals(optionName, StringComparison.OrdinalIgnoreCase)
                                  select op;
             return selectedOption;

--- a/CLImber/AssemblySearcher.cs
+++ b/CLImber/AssemblySearcher.cs
@@ -56,14 +56,14 @@ namespace CLImber
                    select method;
         }
 
-        public static IEnumerable<PropertyInfo> GetCommandOptionPropertyByName(Type type, string optionName, bool ignoreCase = true)
+        public static IEnumerable<PropertyInfo> GetCommandOptionPropertyByName(Type type, string optionName)
         {
             var selectedOption = from op in type.GetProperties()
                                  let attribs = op.GetCustomAttributes<CommandOptionAttribute>()
                                  where (attribs.Count() > 0)
                                  from att in attribs
-                                 where att.Name.Equals(optionName, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal)
-                                    || att.Abbreviation.ToString().Equals(optionName, StringComparison.OrdinalIgnoreCase)
+                                 where att.Name.Equals(optionName, StringComparison.CurrentCultureIgnoreCase )
+                                    || att.Abbreviation.ToString().Equals(optionName, StringComparison.CurrentCultureIgnoreCase)
                                  select op;
             return selectedOption;
         }

--- a/CLImber/CLIHandler.cs
+++ b/CLImber/CLIHandler.cs
@@ -21,8 +21,10 @@ namespace CLImber
             return this;
         }
 
+        public bool IgnoreCommandCase { get; set; }
         public CLIHandler()
         {
+            IgnoreCommandCase = true;
             _converterFuncs[typeof(int)] = (arg) => int.Parse(arg);
         }
 
@@ -121,7 +123,7 @@ namespace CLImber
 
         private Type RetrieveTypeForCommand(string command)
         {
-            var possibleCommandHandlers = AssemblySearcher.GetCommandClasses(command);
+            var possibleCommandHandlers = AssemblySearcher.GetCommandClasses(command, IgnoreCommandCase);
 
             if (possibleCommandHandlers.Count() > 1)
                 throw new Exception($"More than one class assigned to handle command {command}");

--- a/CLImber/CLImber.csproj
+++ b/CLImber/CLImber.csproj
@@ -6,19 +6,17 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageProjectUrl>https://github.com/JosephMartell/CLImber</PackageProjectUrl>
     <RepositoryUrl>https://github.com/JosephMartell/CLImber</RepositoryUrl>
-    <Version>0.5.3</Version>
+    <Version>0.6.0</Version>
     <Authors>Joseph Martell</Authors>
     <Description>CLImber is a Command Line Interface library.</Description>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     <PackageTags>CLI, Command Line, terminal, shell</PackageTags>
     <PackageReleaseNotes>New Features
-- Implements options.
-
-*0.5.1 is being uploaded because 0.5.0 did not make the CommandOptionAttribute class public.
-*0.5.2 is a bug-fix release. Release 0.5.0 did not properly parse commands seperately from options.
-*0.5.3 is a bug-fix release. CLImber would not call the proper command handler if an option taking a parameter was included in the command line.</PackageReleaseNotes>
+- Commands can now be case sensitive or not dendending on how CLImber is configured.
+- The way options are handled have been updated. Options are now processed more closely to how Git handles options. Aggregated options can have up to 1 option that takes a value; values can be designated with '=' or can be implied as the next argument in the command (for both abbreviated or full options).</PackageReleaseNotes>
     <RepositoryType>git</RepositoryType>
     <PackageId>JM.CLImber</PackageId>
+    <Copyright>Joseph Martell</Copyright>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Includes several updates:

- The example project has been updated to create a basic calculator. As more functionality is added to Climber this project will be udpated.
- Commands can now be case sensitive. This is a CLImber level setting and will apply to all commands processed by a single CLIHandler instance.
- Options are processed much more closely to Git. Aggregate options can include up to 1 option that requires a value; abbreviated options can accept values; values can either follow '=' after the option name or can be the very next argument supplied to the program.