### PR TITLE
Hot fix 1.0.1 - Duplicate Arguments Not Accepted

### DIFF
--- a/CLImber.Example/Add.cs
+++ b/CLImber.Example/Add.cs
@@ -3,9 +3,12 @@ using System.Linq;
 
 namespace CLImber.Example
 {
-    [CommandClass("add d", ShortDescription = "Add numbers together")]
-    public class Add
+    [CommandClass("add", ShortDescription = "Add numbers together")]
+    internal class Add
     {
+        [CommandOption("round", Abbreviation = 'r', Description = "If true, round answers to nearest whole number.")]
+        public bool RoundAnswer { get; set; }
+
         [CommandHandler]
         public void AddNumbers(decimal[] numbers)
         {
@@ -13,4 +16,3 @@ namespace CLImber.Example
         }
     }
 }
-    

--- a/CLImber.Example/Add.cs
+++ b/CLImber.Example/Add.cs
@@ -1,13 +1,22 @@
 ﻿using System;
+using System.Linq;
+
 namespace CLImber.Example
 {
     [CommandClass("add", ShortDescription = "Add numbers together")]
-    public class AddCmdHandler
+    public class Add
     {
         [CommandHandler]
         public void AddNumbers(decimal num1, decimal num2)
         {
             Console.WriteLine($"Answer: {num1 + num2}");
         }
+
+        [CommandHandler]
+        public void AddNumbers(decimal[] numbers)
+        {
+            Console.WriteLine($"Answer: {numbers.Sum()}");
+        }
     }
 }
+    

--- a/CLImber.Example/Add.cs
+++ b/CLImber.Example/Add.cs
@@ -3,15 +3,9 @@ using System.Linq;
 
 namespace CLImber.Example
 {
-    [CommandClass("add", ShortDescription = "Add numbers together")]
+    [CommandClass("add d", ShortDescription = "Add numbers together")]
     public class Add
     {
-        [CommandHandler]
-        public void AddNumbers(decimal num1, decimal num2)
-        {
-            Console.WriteLine($"Answer: {num1 + num2}");
-        }
-
         [CommandHandler]
         public void AddNumbers(decimal[] numbers)
         {

--- a/CLImber.Example/CLImber.Example.csproj
+++ b/CLImber.Example/CLImber.Example.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <GenerateDocumentationFile>False</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CLImber.Example/CLImber.Example.csproj
+++ b/CLImber.Example/CLImber.Example.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CLImber.Example/Divide.cs
+++ b/CLImber.Example/Divide.cs
@@ -1,13 +1,21 @@
 ﻿using System;
 namespace CLImber.Example
 {
+    /// <summary>
+    /// Divide numbers
+    /// </summary>
     [CommandClass("div", ShortDescription = "Divide numbers")]
     public class Divide
     {
+        /// <summary>
+        /// Divide numbers
+        /// </summary>
+        /// <param name="numerator">Numerator</param>
+        /// <param name="divisor">Divisor</param>
         [CommandHandler]
-        public void DivideNumbers(decimal num1, decimal num2)
+        public void DivideNumbers(decimal numerator, decimal divisor)
         {
-            Console.WriteLine($"Answer: {num1 / num2}");
+            Console.WriteLine($"Answer: {numerator / divisor}");
         }
     }
 }

--- a/CLImber.Example/Multiply.cs
+++ b/CLImber.Example/Multiply.cs
@@ -1,13 +1,15 @@
 ﻿using System;
+using System.Linq;
+
 namespace CLImber.Example
 {
     [CommandClass("mul", ShortDescription = "Multiply numbers")]
     public class Multiply
     {
         [CommandHandler]
-        public void MultiplyNumbers(decimal num1, decimal num2)
+        public void MultiplyNumbers(decimal[] numbers)
         {
-            Console.WriteLine($"Answer: {num1 * num2}");
+           Console.WriteLine($"Answer: {numbers.Aggregate(1.0m, (a, b) => a * b)}");
         }
     }
 }

--- a/CLImber.Example/Multiply.cs
+++ b/CLImber.Example/Multiply.cs
@@ -3,9 +3,16 @@ using System.Linq;
 
 namespace CLImber.Example
 {
+    /// <summary>
+    /// Multiply any quantity of numbers
+    /// </summary>
     [CommandClass("mul", ShortDescription = "Multiply numbers")]
     public class Multiply
     {
+        /// <summary>
+        /// Multiplies any quantity of numbers
+        /// </summary>
+        /// <param name="numbers">Supply numbers separated by spaces</param>
         [CommandHandler]
         public void MultiplyNumbers(decimal[] numbers)
         {

--- a/CLImber.Example/Properties/launchSettings.json
+++ b/CLImber.Example/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "CLImber.Example": {
       "commandName": "Project",
-      "commandLineArgs": "edit \"--name=Updated name\""
+      "commandLineArgs": "add 4 18 20 57 1239"
     }
   }
 }

--- a/CLImber.Example/Subtract.cs
+++ b/CLImber.Example/Subtract.cs
@@ -3,9 +3,16 @@ using System.Linq;
 
 namespace CLImber.Example
 {
+    /// <summary>
+    /// Subtract any quantity of numbers
+    /// </summary>
     [CommandClass("sub", ShortDescription = "Subtract numbers")]
     public class Subtract
     {
+        /// <summary>
+        /// Subtract any number of numbers. Numbers are subtracted in the order they are entered.
+        /// </summary>
+        /// <param name="numbers">A list of numbers to subtract. The first number is considered the start. For example, the numbers 5 15 -9 would be interpreted as 5 - 4 - (-9) and return the value -1.</param>
         [CommandHandler]
         public void SubNumbers(decimal[] numbers)
         {

--- a/CLImber.Example/Subtract.cs
+++ b/CLImber.Example/Subtract.cs
@@ -1,13 +1,15 @@
 ﻿using System;
+using System.Linq;
+
 namespace CLImber.Example
 {
     [CommandClass("sub", ShortDescription = "Subtract numbers")]
     public class Subtract
     {
         [CommandHandler]
-        public void SubNumbers(decimal num1, decimal num2)
+        public void SubNumbers(decimal[] numbers)
         {
-            Console.WriteLine($"Answer: {num1 - num2}");
+            Console.WriteLine($"Answer: {numbers.First() + numbers.Skip(1).Sum(s => -1 * s)}");
         }
     }
 }

--- a/CLImber.Tests/CLIHandlerTests.cs
+++ b/CLImber.Tests/CLIHandlerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using FluentAssertions;
 using Xunit;
 
@@ -41,6 +42,7 @@ namespace CLImber.Tests
         public static string[] CommandArgs { get; set; } = new string[0];
 
         public static decimal[] OverloadedArgs { get; private set; } = new decimal[0];
+        public static int Total { get; set; }
 
         public static void ResetIndicators()
         {
@@ -153,6 +155,12 @@ namespace CLImber.Tests
         public void ThrowsException(int a, int b)
         {
             throw new System.Exception("Test exception");
+        }
+
+        [CommandHandler]
+        public void MultipleInts(int a, int b, int c)
+        {
+            Total = a + b + c;
         }
     }
 
@@ -390,13 +398,22 @@ namespace CLImber.Tests
         [Fact]
         public void Handle_WorksWithOverloadedArrayMethods()
         {
-            string[] arguments = { "test_command", "5", "7", "87.6" };
+            string[] arguments = { "test_command", "5", "7", "87.6", "111.111" };
 
             _sut.Invoking(y => y.Handle(arguments))
                 .Should().NotThrow();
-            DummyCommand.OverloadedArgs.Length.Should().Be(3);
+            DummyCommand.OverloadedArgs.Length.Should().Be(4);
 
         }
 
+        [Fact]
+        public void Handle_ParsesIntegerArguments_WhenMultipleAreZero()
+        {
+            string[] arguments = { "test_command", "0", "0", "0" };
+            DummyCommand.Total = -1;
+            _sut.Handle(arguments);
+            DummyCommand.Total.Should().Be(0);
+
+        }
     }
 }

--- a/CLImber.Tests/CLIHandlerTests.cs
+++ b/CLImber.Tests/CLIHandlerTests.cs
@@ -361,7 +361,7 @@ namespace CLImber.Tests
             string[] arguments = { "test_command", "5", "7" };
 
             _sut.Invoking(y => y.Handle(arguments))
-                .Should().Throw<System.Exception>();
+                .Should().Throw<System.Exception>().Where(e => e.GetType() != typeof(System.Reflection.TargetInvocationException));
         }
 
         [Fact]

--- a/CLImber.Tests/CLIHandlerTests.cs
+++ b/CLImber.Tests/CLIHandlerTests.cs
@@ -3,6 +3,23 @@ using Xunit;
 
 namespace CLImber.Tests
 {
+    [CommandClass("decimal_command")]
+    public class DecimalDummyCmd
+    {
+        public static decimal[] _args;
+
+        public static void ResetIndicators()
+        {
+            _args = null;
+        }
+
+        [CommandHandler]
+        public void ConvertToDecimalArray(decimal[] args)
+        {
+            _args = args;
+        }
+
+    }
 
     [CommandClass("test_command")]
     public class DummyCommand
@@ -19,6 +36,12 @@ namespace CLImber.Tests
 
         public static string CommandArg { get; private set; } = string.Empty;
 
+        public static int OverloadCmdArg { get; private set; } = 0;
+
+        public static string[] CommandArgs { get; set; } = new string[0];
+
+        public static decimal[] OverloadedArgs { get; private set; } = new decimal[0];
+
         public static void ResetIndicators()
         {
             CallCount = 0;
@@ -27,6 +50,9 @@ namespace CLImber.Tests
             StringOption = string.Empty;
             IntOption = 0;
             CommandArg = string.Empty;
+            OverloadCmdArg = 0;
+            CommandArgs = new string[0];
+            OverloadedArgs = new decimal[0];
         }
 
         public DummyCommand()
@@ -50,6 +76,12 @@ namespace CLImber.Tests
         {
             CallCount++;
             CommandArg = arg1;
+        }
+
+        [CommandHandler]
+        public void OverloadHandler(int arg1)
+        {
+            OverloadCmdArg = arg1;
         }
 
         [CommandOption("flag", Abbreviation = 'f')]
@@ -103,6 +135,24 @@ namespace CLImber.Tests
                 IntOption = value;
             }
 
+        }
+
+        [CommandHandler]
+        public void StringArrayHandler(string[] args)
+        {
+            CommandArgs = args;
+        }
+
+        [CommandHandler]
+        public void OverloadedArrayHanlder(decimal[] args)
+        {
+            OverloadedArgs = args;
+        }
+
+        [CommandHandler]
+        public void ThrowsException(int a, int b)
+        {
+            throw new System.Exception("Test exception");
         }
     }
 
@@ -295,5 +345,58 @@ namespace CLImber.Tests
             _sut.Handle(arguments);
             DummyCommand.CallCount.Should().Be(0);
         }
+
+        [Fact]
+        public void Handle_PassesNArguments_WhenHandlerAcceptsArray()
+        {
+            string[] arguments = { "test_command", "arg1", "arg2", "arg3", "arg4" };
+
+            _sut.Handle(arguments);
+            DummyCommand.CommandArgs.Should().HaveCount(4);
+        }
+
+        [Fact]
+        public void Handle_PropagatesExceptions_WhenThrownInInvokedMethod()
+        {
+            string[] arguments = { "test_command", "5", "7" };
+
+            _sut.Invoking(y => y.Handle(arguments))
+                .Should().Throw<System.Exception>();
+        }
+
+        [Fact]
+        public void Handle_ConvertsToDecimalArray_WhenCalled()
+        {
+            string[] arguments = { "decimal_command", "5", "7", "87.6" };
+
+            _sut.Invoking(y => y.Handle(arguments))
+                .Should().NotThrow();
+            DecimalDummyCmd._args.Length.Should().Be(3);
+
+        }
+    
+        [Fact]
+        public void Handle_ChoosesOverloadedHandlers_BasedOnSuppliedType()
+        {
+            string[] arguments = { "test_command", "this is the argument" };
+            _sut.Handle(arguments);
+            DummyCommand.CommandArg.Should().Be("this is the argument");
+
+            string[] olArguments = { "test_command", "5" };
+            _sut.Handle(olArguments);
+            DummyCommand.OverloadCmdArg.Should().Be(5);
+        }
+
+        [Fact]
+        public void Handle_WorksWithOverloadedArrayMethods()
+        {
+            string[] arguments = { "test_command", "5", "7", "87.6" };
+
+            _sut.Invoking(y => y.Handle(arguments))
+                .Should().NotThrow();
+            DummyCommand.OverloadedArgs.Length.Should().Be(3);
+
+        }
+
     }
 }

--- a/CLImber/AssemblySearcher.cs
+++ b/CLImber/AssemblySearcher.cs
@@ -50,9 +50,24 @@ namespace CLImber
         {
             return from method in type.GetMethods()
                    let attributes = method.GetCustomAttributes(typeof(CommandHandlerAttribute), true)
+                   let parms = method.GetParameters()
                    where (attributes != null && attributes.Length > 0)
-                      && (method.GetParameters().Count() == argumentCount)
-                   orderby method.GetParameters().Count() ascending
+                      && (parms.Count() == argumentCount)
+                      && (parms.Where(p => p.ParameterType.ToString().Contains("[]")).Count() == 0)
+                   orderby parms.Count() ascending,
+                           parms.Count(p => p.ParameterType == typeof(string)) ascending
+                   select method;
+        }
+
+        public static IEnumerable<MethodInfo> GetCommandMethodsAcceptingArrays(Type type)
+        {
+            return from method in type.GetMethods()
+                   let attributes = method.GetCustomAttributes(typeof(CommandHandlerAttribute), true)
+                   let parms = method.GetParameters()
+                   where (attributes != null && attributes.Length > 0)
+                      && (parms.Count() > 0)
+                      && (parms.First().ParameterType.ToString().Contains("[]"))
+                   orderby parms.Count(p => p.ParameterType == typeof(string[])) ascending
                    select method;
         }
 

--- a/CLImber/AssemblySearcher.cs
+++ b/CLImber/AssemblySearcher.cs
@@ -71,6 +71,17 @@ namespace CLImber
                    select method;
         }
 
+        public static IEnumerable<PropertyInfo> GetCommandOptions(Type type)
+        {
+            var selectedOptions = from op in type.GetProperties()
+                                 let attribs = op.GetCustomAttributes<CommandOptionAttribute>()
+                                 where (attribs.Count() > 0)
+                                 from att in attribs
+                                 select op;
+
+            return selectedOptions;
+
+        }
         public static IEnumerable<PropertyInfo> GetCommandOptionPropertyByName(Type type, string optionName)
         {
             var selectedOption = from op in type.GetProperties()

--- a/CLImber/CLIHandler.cs
+++ b/CLImber/CLIHandler.cs
@@ -82,7 +82,7 @@ namespace CLImber
                 var argQ = new Queue<string>(args);
                 string cmdArg = argQ.Dequeue();
                 var options = args.Skip(1).Where(a => a.StartsWith("-"));
-                var cmdArguments = args.Skip(1).Except(options);
+                var cmdArguments = args.Skip(1).Where(a => !options.Contains(a));
                 var commandType = RetrieveTypeForCommand(cmdArg);
                 object cmd = ConstructCmdType(commandType);
                 ParseOptions(cmd, argQ);

--- a/CLImber/CLIHandler.cs
+++ b/CLImber/CLIHandler.cs
@@ -56,7 +56,7 @@ namespace CLImber
             }
             catch (TargetInvocationException tie)
             {
-                throw tie;
+                throw tie.InnerException;
             }
             catch (Exception ex)
             {

--- a/CLImber/CLIHandler.cs
+++ b/CLImber/CLIHandler.cs
@@ -6,10 +6,22 @@ using System.Reflection;
 
 namespace CLImber
 {
-    public class CLIHandler
+    /// <summary>
+    /// The primary class in the CLImber library. This class handles parsing command line arguments,
+    /// determining which method to call, setting options, and converting arguments to the right type,
+    /// and finally making the actual method call.
+    /// </summary>
+    public sealed class CLIHandler
     {
         private readonly Dictionary<Type, Func<string, object>> _converterFuncs = new Dictionary<Type, Func<string, object>>();
 
+        /// <summary>
+        /// Provide a function that converts from a command line argument (string) to a different type.
+        /// This allows CLImber to work with strongly typed arguments for CommandHandler methods.
+        /// </summary>
+        /// <typeparam name="T">The type that will be passed to the handler method.</typeparam>
+        /// <param name="converterFunc">The function that performs the conversion.</param>
+        /// <returns>This instance of CLIHandler to facilitate fluent programming style.</returns>
         public CLIHandler RegisterTypeConverter<T>(Func<string, object> converterFunc)
         {
             _converterFuncs[typeof(T)] = converterFunc;
@@ -17,15 +29,33 @@ namespace CLImber
         }
 
         private readonly Dictionary<Type, object> _resources = new Dictionary<Type, object>();
-
+        /// <summary>
+        /// A collection of resources that can be used for rudimentary dependancy injection.
+        /// </summary>
+        /// <typeparam name="T">The registered type of the resource. Generally should be an interface.</typeparam>
+        /// <param name="resource">The instance/resource that will be provided if required by the CommandClass instance.</param>
+        /// <returns>This instance of CLIHandler to facilitate fluent programming style.</returns>
         public CLIHandler RegisterResource<T>(T resource)
         {
             _resources[typeof(T)] = resource;
             return this;
         }
 
+        /// <summary>
+        /// If true, CLIHandler will ignore case when matching CLI commands. If false, the case of all CLI 
+        /// commands must match the string provided in the CommandClass attribute exactly.
+        /// </summary>
         public bool IgnoreCommandCase { get; set; }
 
+        /// <summary>
+        /// Provide a program description for program help and documentation.
+        /// </summary>
+        public string ProgramDescription { get; set; }
+
+        /// <summary>
+        /// Number of columns to use for printing text. Set to 0 or less to disable column restriction.
+        /// </summary>
+        public int ColumnCount { get; set; } = 0;
         public CLIHandler()
         {
             IgnoreCommandCase = true;
@@ -35,11 +65,15 @@ namespace CLImber
             _converterFuncs[typeof(decimal)] = (arg) => decimal.Parse(arg);
         }
 
+        /// <summary>
+        /// Parses command line arguments and then invoke the required handler methods.
+        /// </summary>
+        /// <param name="args">The command line arguments passed to your Main method.</param>
         public void Handle(IEnumerable<string> args)
         {
             if (args.Count() <= 0)
             {
-                UsageDocumenter.ShowUsageForAll();
+                UsageDocumenter.ShowUsageForAll(ProgramDescription);
                 return;
             }
 
@@ -63,7 +97,6 @@ namespace CLImber
                 Console.WriteLine(ex.Message);
             }
         }
-
         private void ParseOptions(object commandObject, Queue<string> argQ)
         {
             var passedOptions = new Queue<string>();
@@ -96,7 +129,6 @@ namespace CLImber
                 }
             }
         }
-
         private void SetFullOption(object commandObject, Queue<string> argQ, string options, string value)
         {
             var optionProperty = AssemblySearcher
@@ -117,7 +149,6 @@ namespace CLImber
                 optionProperty.SetValue(commandObject, _converterFuncs[optionProperty.PropertyType](value ?? argQ.Dequeue()));
             }
         }
-
         private void SetAggregatedOptions(object commandObject, Queue<string> argQ, string options, string value)
         {
             var argsRequired = 0;
@@ -151,7 +182,6 @@ namespace CLImber
             }
 
         }
-
         private Type RetrieveTypeForCommand(string command)
         {
             var possibleCommandHandlers = AssemblySearcher.GetCommandClasses(command, IgnoreCommandCase);
@@ -164,7 +194,6 @@ namespace CLImber
 
             return possibleCommandHandlers.First();
         }
-
         private object ConstructCmdType(Type commandType)
         {
             if (commandType.GetConstructors().First().GetParameters().Count() < 1)
@@ -247,7 +276,6 @@ namespace CLImber
             List<object> convertedParams = ConvertParams(handlerMethod.GetParameters(), paramArgs);
             handlerMethod.Invoke(cmd, convertedParams.ToArray());
         }
-
         private List<object> ConvertParams(IEnumerable<ParameterInfo> methodParms, IEnumerable<string> paramArgs)
         {
             List<object> convertedParams = new List<object>();
@@ -260,7 +288,6 @@ namespace CLImber
 
             return convertedParams;
         }
-
         private object ConvertParam(string parameter, Type desiredType)
         {
             if (desiredType == typeof(string))

--- a/CLImber/CLImber.csproj
+++ b/CLImber/CLImber.csproj
@@ -6,19 +6,17 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageProjectUrl>https://github.com/JosephMartell/CLImber</PackageProjectUrl>
     <RepositoryUrl>https://github.com/JosephMartell/CLImber</RepositoryUrl>
-    <Version>0.5.3</Version>
+    <Version>0.6.0</Version>
     <Authors>Joseph Martell</Authors>
     <Description>CLImber is a Command Line Interface library.</Description>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     <PackageTags>CLI, Command Line, terminal, shell</PackageTags>
     <PackageReleaseNotes>New Features
-- Implements options.
-
-*0.5.1 is being uploaded because 0.5.0 did not make the CommandOptionAttribute class public.
-*0.5.2 is a bug-fix release. Release 0.5.0 did not properly parse commands seperately from options.
-*0.5.3 is a bug-fix release. CLImber would not call the proper command handler if an option taking a parameter was included in the command line.</PackageReleaseNotes>
+- Commands can now be case sensitive or not dendending on how CLImber is configured.
+- The way options are handled have been updated. Options are now processed more closely to how Git handles options. Aggregated options can have up to 1 option that takes a value; values can be designated with '=' or can be implied as the next argument in the command (for both abbreviated or full options).</PackageReleaseNotes>
     <RepositoryType>git</RepositoryType>
     <PackageId>JM.CLImber</PackageId>
+    <Copyright>Joseph Martell</Copyright>
   </PropertyGroup>
 
 </Project>

--- a/CLImber/CLImber.csproj
+++ b/CLImber/CLImber.csproj
@@ -2,18 +2,16 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageProjectUrl>https://github.com/JosephMartell/CLImber</PackageProjectUrl>
     <RepositoryUrl>https://github.com/JosephMartell/CLImber</RepositoryUrl>
-    <Version>0.6.0</Version>
+    <Version>1.0.0</Version>
     <Authors>Joseph Martell</Authors>
     <Description>CLImber is a Command Line Interface library.</Description>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     <PackageTags>CLI, Command Line, terminal, shell</PackageTags>
-    <PackageReleaseNotes>New Features
-- Commands can now be case sensitive or not dendending on how CLImber is configured.
-- The way options are handled have been updated. Options are now processed more closely to how Git handles options. Aggregated options can have up to 1 option that takes a value; values can be designated with '=' or can be implied as the next argument in the command (for both abbreviated or full options).</PackageReleaseNotes>
+    <PackageReleaseNotes>Includes significant udpates to allow better descriptions via attributes and does a more complete job of automatically generating command line documentation.</PackageReleaseNotes>
     <RepositoryType>git</RepositoryType>
     <PackageId>JM.CLImber</PackageId>
     <Copyright>Joseph Martell</Copyright>

--- a/CLImber/CommandClassAttribute.cs
+++ b/CLImber/CommandClassAttribute.cs
@@ -3,7 +3,7 @@
 namespace CLImber
 {
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
-    public class CommandClassAttribute
+    public sealed class CommandClassAttribute
         : System.Attribute
     {
         public string ShortDescription { get; set; }

--- a/CLImber/CommandHandlerAttribute.cs
+++ b/CLImber/CommandHandlerAttribute.cs
@@ -2,10 +2,16 @@
 
 namespace CLImber
 {
+    /// <summary>
+    /// Used to denote a method in a CommandClass that is a valid handler for a command.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
-    public class CommandHandlerAttribute
+    public sealed class CommandHandlerAttribute
         : System.Attribute
     {
+        /// <summary>
+        /// Provide a short description that will provide a basic help message on the command line.
+        /// </summary>
         public string ShortDescription { get; set; }
     }
 }

--- a/CLImber/CommandOptionAttribute.cs
+++ b/CLImber/CommandOptionAttribute.cs
@@ -3,12 +3,14 @@
 namespace CLImber
 {
     [AttributeUsage(AttributeTargets.Property, AllowMultiple =true, Inherited = false)]
-    public class CommandOptionAttribute
+    public sealed class CommandOptionAttribute
         : Attribute
     {
         public string Name { get; }
 
         public char Abbreviation { get; set; }
+
+        public string Description { get; set; }
         public CommandOptionAttribute(string name)
         {
             Name = name;

--- a/CLImber/UsageDocumenter.cs
+++ b/CLImber/UsageDocumenter.cs
@@ -149,7 +149,6 @@ namespace CLImber
                 return lines;
             }
 
-            int i = 1;
             string line = string.Empty;
             while (text.Length > width)
             {

--- a/CLImber/UsageDocumenter.cs
+++ b/CLImber/UsageDocumenter.cs
@@ -1,44 +1,193 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace CLImber
 {
+    //Here are the conventions that CLImber is going to use when describing CLIs:
+    //Commands
+    //     Commands are shown as plain-text words. 
+    //
+    //Arguments
+    //     Arguments will be shown in either all CAPS or in angle brackets: <>
+    //
+    //Options
+    //     Options will be delineated by starting either with "-" or "--"
+    //
+    //Optional elements will be shown in square brackets: []
+    //Required elements will be shown in parenthesis: (). Elements that lack any decoration are also considered required.
+    //Mutually exclusive options will be separated by a pipe: |
+    //Elements that can be repeated will be followed by ellipsis: ...
+    //These decisions are based off of the docopt conventions
+
+    //Generated program documentation is going to take this format, by default:
+    //program_name
+    //
+    //Commands:
+    //command_name
+    //Short description of what this does
+    //  Usage:
+    //      program_name command_name <argument> [options]
+    //      program_name command_name <argument1> <argument2> [options]
+    //      program_name command_name <argument1>...
+    //
+    //  Options
+    //      --option1, -a                   Option 1 description
+    //      --option2, -b                   Option 2 description
+    //      --option3=<text>, -c=<text>     Option 3 description
+
     internal static class UsageDocumenter
     {
-        public static void ShowUsageForAll()
+        //If <= 0 will ignore max width. 
+        public static int MaxWidth { get; set; } = 120;
+        private static string Indent(int levels)
         {
+            if (levels <= 0)
+                levels = 0;
+            return new string(' ', 4 * levels);
+        }
+        public static void ShowUsageForAll(string programDescription = "")
+        {
+            var programName = Assembly.GetEntryAssembly().GetName();
+            Console.WriteLine(programName.Name + " " + programName.Version);
+            Console.WriteLine($"{programDescription}\n");
+            Console.WriteLine("Commands:");
+
             var cmdTypes = AssemblySearcher
                 .GetCommandClasses()
                 .OrderBy(t => AssemblySearcher.GetCommandName(t));
 
-            //foreach type get the names of the parameters and create a printout
-            foreach (var type in cmdTypes)
+            cmdTypes.ToList().ForEach(ShowUsageForType);
+        }
+        private static void ShowUsageForType(Type type)
+        {
+            var cmdName = AssemblySearcher.GetCommandName(type);
+            Console.WriteLine($"{cmdName}");
+
+            var desc = type.GetCustomAttributes<CommandClassAttribute>().First().ShortDescription;
+
+            if (desc?.Length > 0)
             {
-
-                var cmdName = AssemblySearcher.GetCommandName(type);
-                Console.WriteLine($"{cmdName} command");
-                var desc = type.GetCustomAttributes(typeof(CommandClassAttribute), false).Cast<CommandClassAttribute>().First().ShortDescription;
-                if (desc?.Length > 0)
-                {
-                    Console.WriteLine(desc);
-                }
-
-                Console.WriteLine($"usage:");
-
-                foreach (var method in AssemblySearcher.GetCommandMethods(type))
-                {
-                    var handlerDesc = method.GetCustomAttributes(typeof(CommandHandlerAttribute), false).Cast<CommandHandlerAttribute>().First().ShortDescription;
-                    StringBuilder sb = new StringBuilder();
-                    sb.Append(cmdName).Append(" ");
-                    foreach (var param in method.GetParameters())
-                    {
-                        sb.Append(param.Name).Append(" ");
-                    }
-                    Console.WriteLine($"  {sb,-60} {handlerDesc}");
-                }
-                Console.WriteLine("\n");
+                Console.WriteLine($"{Indent(1)}{desc}");
             }
+            
+            PrintUsageDocumentation(type, cmdName);
+            PrintOptionsDocumentation(type);
+            Console.WriteLine("\n");
+        }
+
+        //TODO: This is a mess. Clean it up.
+        private static void PrintUsageDocumentation(Type type, string cmdName)
+        {
+            bool hasOptions = AssemblySearcher.GetCommandOptions(type).Count() > 0;
+            Console.WriteLine($"    usage:");
+
+            List<(string usage, string desc)> methodDescriptions = new List<(string usage, string desc)>();
+            foreach (var method in AssemblySearcher.GetCommandMethods(type))
+            {
+                var handlerDesc = method
+                    .GetCustomAttributes<CommandHandlerAttribute>()
+                    .First().ShortDescription;
+
+                StringBuilder sb = new StringBuilder();
+                sb.Append(cmdName).Append(" ");
+                foreach (var param in method.GetParameters())
+                {
+                    sb.Append($"<{param.Name}>").Append(param.ParameterType.Name.Contains("[]") ?  "... " : " ");
+                }
+
+                if (hasOptions)
+                {
+                    sb.Append("[options] ");
+                }
+                methodDescriptions.Add((sb.ToString(), handlerDesc));
+            }
+
+            if (methodDescriptions.Count > 0)
+            {
+                var col1Width = methodDescriptions.Max(d => d.usage.Length) + Indent(2).Length + 2;
+                foreach (var md in methodDescriptions)
+                {
+                    string usagePrint = Indent(2) + md.usage;
+                    usagePrint = usagePrint.PadRight(col1Width, ' ');
+                    string fullLine = $"{usagePrint}{md.desc}";
+                    if ((MaxWidth > 0) && (fullLine.Length > MaxWidth))
+                    {
+                        var lastSpaceIndex = fullLine.LastIndexOf(' ', MaxWidth - 1, MaxWidth) + 1;
+                        Console.WriteLine(fullLine.Substring(0, lastSpaceIndex));
+                        int descIndent = usagePrint.Length;
+                        do
+                        {
+                            fullLine = new string(' ', descIndent)+ fullLine.Substring(lastSpaceIndex);
+                            if (fullLine.Length > MaxWidth)
+                            {
+                                Console.WriteLine(fullLine.Substring(0, MaxWidth));
+                            }
+                            else
+                            {
+                                Console.WriteLine(fullLine);
+                            }
+                        } while (fullLine.Length > MaxWidth);
+                    }
+                    else
+                    {
+                        Console.WriteLine($"{usagePrint}{md.desc}");
+                    }
+                }
+            }
+        }
+
+        private static IEnumerable<string> SplitToLines(string text, int width)
+        {
+            List<string> lines = new List<string>();
+            if (text.Length <= width)
+            {
+                lines.Add(text);
+                return lines;
+            }
+
+            int i = 1;
+            string line = string.Empty;
+            while (text.Length > width)
+            {
+                line = text.Substring(0, text.LastIndexOf(' ', width - 1, width) + 1);
+                lines.Add(line);
+                text = text.Substring(width);
+            }
+            lines.Add(text);
+            return lines;
+        }
+
+        private static void PrintOptionsDocumentation(Type type)
+        {
+            var optionList = from option in AssemblySearcher.GetCommandOptions(type)
+                             from attributes in option.GetCustomAttributes<CommandOptionAttribute>()
+                             select (attributes.Name, attributes.Abbreviation, attributes.Description, option.PropertyType);
+
+
+            if (optionList.Count() > 0)
+            {
+                //6 spaces accounts for 4 spaces to print an abbreviated option (in the form of ', -o') or 4 spaces if no abbreviation is present, plus 2 hyphens to precede the full option.
+                int longestItem = Indent(2).Length + optionList.Max(o => o.Name.Length + o.PropertyType.Name.Length + 3) + 6;
+
+                var linesToPrint = from o in optionList
+                                   select OptionStart(o, longestItem) + "  " + o.Description;
+
+                Console.WriteLine("\n    options");
+                linesToPrint.ToList().ForEach(Console.WriteLine);
+            }
+        }
+
+        private static string OptionStart((string name, char abbreviation, string description, Type type) optionInfo, int width)
+        {
+            string start = Indent(2) + "--" + optionInfo.name;
+            start += (optionInfo.abbreviation == '\0' ? "    " : ",-" + optionInfo.abbreviation);
+            start += (optionInfo.type != typeof(bool) ? " =<" + optionInfo.type.Name + ">" : "").PadLeft(width - start.Length);
+
+            return start;
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ namespace CLImber.Example
 ```
 
 ### Register the `checkout` command with CLImber
-At runtime, CLImber uses reflection to scan the codebase and find all classes decorated with the `CommandClass` attribute. In our code example we have decorated our CheckoutCommand class with the `CommandClass` attribute and an "checkout" argument. This argument determines the expected string on the command line that CLImber will use to invoke this command.
+At runtime, CLImber uses reflection to scan the codebase and find all classes decorated with the `CommandClass` attribute. In our code example we have decorated our CheckoutCommand class with the `CommandClass` attribute and provided a "checkout" argument. This argument determines the name of the command that CLImber will associate with this class.
 ```c#
     ...
     [CommandClass("checkout")]
@@ -60,7 +60,7 @@ At runtime, CLImber uses reflection to scan the codebase and find all classes de
     ...
 ```
 ### Create the new-branch option
-The git checkout command accepts an option to create a new branch instead of switching to an existing branch. To implement this in CLImber we create an attribute in our CheckoutCommand class:
+The git checkout command accepts an option to create a new branch instead of switching to an existing branch. To implement this in CLImber we create a property in our CheckoutCommand class:
 
 ```c#
     ...
@@ -68,7 +68,7 @@ The git checkout command accepts an option to create a new branch instead of swi
         public bool NewBranch { get; set; }
     ...
 ```
-By decorating our property with the `CommandOption` attribute CLImber will recognize that this property is an option. The first argument is the full option name which would be invoked by using `--new-branch ` on the command line. The `Abbreviation` parameter designates the character used to invoke this option using abbreviated syntax. On the command line this would look like: `-b`.
+By decorating our property with the `CommandOption` attribute CLImber will recognize that this property is an option for the checkout command. The first argument is the full option name which would be invoked by using `--new-branch ` on the command line. The `Abbreviation` parameter designates the character used to invoke this option using abbreviated syntax. On the command line this would look like: `-b`.
 
 ### Create the command handler method
 We have already flagged the `CheckoutCommand` class as representing the `checkout` command. But we haven't told CLImber that we are expecting a single string argument to be provided when the `checkout` command is invoked. To do this we add a `CommandHandler` method to our class like this:


### PR DESCRIPTION
CLImber had a bug where duplicate arguments would not be recognized. The code used the Except function which only returned unique entries.